### PR TITLE
Add training directory for v0.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,4 @@ notebooks/
 summarized_metrics/
 project.lock
 wandb/
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ summarized_metrics/
 project.lock
 wandb/
 .vscode/
+gcs_creds.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="https://raw.githubusercontent.com/ljvmiranda921/calamanCy/master/logo.png" width="125" height="125" align="right" />
 
-# calamanCy: NLP pipelines for Tagalog [WIP]
+# calamanCy: NLP pipelines for Tagalog
 
 **calamanCy** is a Tagalog natural language preprocessing framework made with
 [spaCy](https://spacy.io). Its goal is to provide pipelines and datasets for

--- a/datasets/tl_calamancy_gold_corpus/scripts/benchmark.py
+++ b/datasets/tl_calamancy_gold_corpus/scripts/benchmark.py
@@ -17,7 +17,7 @@ def benchmark(
     num_trials: int = Opt(NUM_TRIALS, "--num-trials", "-n", help="Set the number of trials to run the experiment."),
     subcommand: str = Opt("ner", "--subcommand", "-C", help="Workflow command to run."),
     config: str = Opt("ner_chars.cfg", "--config", "-c", help="Name of the configuration file to use."),
-    init_tok2vec: Optional[Path] = Opt(None, "--init-tok2vec", "-w", help="Path to the pretrained weights using the baseline configuration"), 
+    init_tok2vec: Optional[Path] = Opt(None, "--init-tok2vec", "-w", help="Path to the pretrained weights using the baseline configuration"),
     vectors: Optional[Path] = Opt(None, "--vectors", "-v", help="Path to the initialized fastText static vectors."),
     trf_model_name: Optional[str] = Opt(None, "--trf-model-name", "--trf", help="Transformer model name from Huggingface."),
     gpu_id: int = Opt(0, "--gpu-id", "-G", help="Set the GPU ID. Use -1 for CPU."),

--- a/datasets/tl_calamancy_gold_corpus/scripts/wandb_sweep.py
+++ b/datasets/tl_calamancy_gold_corpus/scripts/wandb_sweep.py
@@ -25,7 +25,7 @@ app = typer.Typer()
 def wandb_sweep(
     # fmt: off
     ctx: typer.Context,
-    default_config: Path = typer.Argument(..., help="Path to the spaCy training configuration."), 
+    default_config: Path = typer.Argument(..., help="Path to the spaCy training configuration."),
     sweep_id: Optional[str] = typer.Option(None, "--sweep-id", "--id", help="Agent id to resume an already started sweep."),
     wandb_config: Path = typer.Option(DEFAULT_WANDB_CONFIG, "--wandb-config", "--config", "-C", help="Path to the WandB YAML configuration file."),
     num_trials: int = typer.Option(30, "--num-trials", "-n", help="Number of trials to run the each hyperparameter combination."),

--- a/datasets/tl_calamancy_silver_corpus/scripts/process_tlunified.py
+++ b/datasets/tl_calamancy_silver_corpus/scripts/process_tlunified.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional, Tuple
 
 import spacy
 import typer
-from spacy.tokens import Doc, DocBin
+from spacy.tokens import DocBin
 from tqdm import tqdm
 from wasabi import msg
 

--- a/models/v0.1.0/README.md
+++ b/models/v0.1.0/README.md
@@ -2,7 +2,33 @@
 
 # 🪐 spaCy Project: Release v0.1.0
 
-This is a spaCy project that trains the v0.1.0 models for calamanCy.
+This is a spaCy project that trains the v0.1.0 models for calamanCy. You can
+use this project to replicate the pipelines shipped by the project. First, you need to install the
+required dependencies:
+
+```
+pip install -r requirements.txt
+```
+
+Then you need to download all the assets (corpora, static vectors, etc.) via:
+
+```
+python -m spacy project assets
+```
+
+Before training the pipelines, you first need to run the setup workflow. This step prepares the
+corpora for training (or pretraining) and builds the necessary binaries for other downstream commands.
+
+```
+python -m spacy project run setup
+```
+
+You can then train a pipeline by passing its name to the spaCy project command. For example, if you wish to train
+`tl_calamancy_md`, you can execute the corresponding workflow like so:
+
+```
+python -m spacy project run tl-calamancy-md 
+```
 
 
 ## 📋 project.yml
@@ -19,7 +45,21 @@ Commands are only re-run if their inputs have changed.
 
 | Command | Description |
 | --- | --- |
-| `setup` | Prepare the Tagalog corpora and word vectors |
+| `setup-training-data` | Prepare the Tagalog corpora used for training various spaCy components |
+| `setup-pretraining-data` | Prepare the Tagalog corpora used for self-supervised learning operations |
+| `setup-fasttext-vectors` | Make fastText vectors spaCy compatible |
+| `build-floret` | Build floret binary for training fastText / floret vectors |
+| `train-vectors-md` | Train medium-sized word vectors (200 dims, 50k keys) using the floret binary. |
+| `train-vectors-lg` | Train large-sized word vectors (200 dims, 200k keys) using the floret binary. |
+| `pretrain-md` | Pretrain with information from raw text using floret (md) vectors |
+| `pretrain-lg` | Pretrain with information from raw text using fastText vectors |
+| `train-parser-tagger` | Train the parser and tagger components using the Universal Dependencies Ugnayan Treebank |
+| `train-ner-md` | Train NER component of tl_calamancy_md using floret vectors with pretraining (50k unique vectors) |
+| `train-ner-lg` | Train NER component of tl_calamancy_lg using fastText vectors with pretraining (714k unique keys) |
+| `train-ner-trf` | Train NER component of tl_calamancy_trf using context-sensitive vectors from roberta-tagalog |
+| `assemble-trf` | Assemble the tl_calamancy_trf model and package it as a spaCy pipeline |
+| `assemble-lg` | Assemble the tl_calamancy_lg model and package it as a spaCy pipeline |
+| `assemble-md` | Assemble the tl_calamancy_md model and package it as a spaCy pipeline |
 
 ### ⏭ Workflows
 
@@ -30,9 +70,10 @@ inputs have changed.
 
 | Workflow | Steps |
 | --- | --- |
-| `tl-calamancy-trf` | `setup` |
-| `tl-calamancy-lg` | `setup` |
-| `tl-calamancy-md` | `setup` |
+| `setup` | `setup-training-data` &rarr; `setup-pretraining-data` &rarr; `setup-fasttext-vectors` &rarr; `build-floret` |
+| `tl-calamancy-trf` | `train-parser-tagger` &rarr; `train-ner-trf` &rarr; `assemble-trf` |
+| `tl-calamancy-lg` | `pretrain-lg` &rarr; `train-vectors-lg` &rarr; `train-parser-tagger` &rarr; `train-ner-lg` &rarr; `assemble-lg` |
+| `tl-calamancy-md` | `pretrain-md` &rarr; `train-vectors-md` &rarr; `train-parser-tagger` &rarr; `train-ner-md` &rarr; `assemble-md` |
 
 ### 🗂 Assets
 
@@ -43,8 +84,10 @@ in the project directory.
 | File | Source | Description |
 | --- | --- | --- |
 | `assets/corpus.tar.gz` | URL | Annotated TLUnified corpora in spaCy format with train, dev, and test splits. |
-| `assets/vectors.tar.gz` | URL | spaCy-compatible fastText and floret vectors. |
+| `assets/treebank` | Git | Treebank data for UD_Tagalog-Ugnayan |
 | `assets/fasttext.tl.gz` | URL | Tagalog fastText vectors provided from the fastText website (trained from CommonCrawl and Wikipedia). |
-| `assets/tl_tlunified_pt_chars.bin` | URL | Pretraining weights for Tagalog using spaCy's pretrain command (using 'characters' objective). |
+| `assets/tlunified.zip` | URL | TLUnified dataset (from Improving Large-scale Language Models and Resources for Filipino by Cruz and Cheng 2022). |
+| `assets/floret` | Git | Floret repository for training floret and fastText models. |
+| `assets/tlunified_raw_text.jsonl` | URL | Pre-converted raw text from TLUnified in JSONL format (1.1 GB). |
 
 <!-- SPACY PROJECT: AUTO-GENERATED DOCS END (do not remove) -->

--- a/models/v0.1.0/README.md
+++ b/models/v0.1.0/README.md
@@ -3,32 +3,38 @@
 # 🪐 spaCy Project: Release v0.1.0
 
 This is a spaCy project that trains the v0.1.0 models for calamanCy. You can
-use this project to replicate the pipelines shipped by the project. First, you need to install the
-required dependencies:
+use this project to replicate the pipelines shipped by the project. First, you
+need to install the required dependencies:
 
 ```
 pip install -r requirements.txt
 ```
 
-Then you need to download all the assets (corpora, static vectors, etc.) via:
+Then run the set-up commands:
 
 ```
 python -m spacy project assets
-```
-
-Before training the pipelines, you first need to run the setup workflow. This step prepares the
-corpora for training (or pretraining) and builds the necessary binaries for other downstream commands.
-
-```
 python -m spacy project run setup
 ```
 
-You can then train a pipeline by passing its name to the spaCy project command. For example, if you wish to train
-`tl_calamancy_md`, you can execute the corresponding workflow like so:
+This step downloads all assets and prepares all the datasets and binaries for
+training use.  You can then train a pipeline by passing its name to the spaCy
+project command. For example, if you wish to train `tl_calamancy_md`, you can
+execute the corresponding workflow like so:
 
 ```
 python -m spacy project run tl-calamancy-md 
 ```
+
+## Model information
+
+| Model                       | Pipelines                                   | Description                                                                                                  |
+|-----------------------------|---------------------------------------------|--------------------------------------------------------------------------------------------------------------|
+| tl_calamancy_md (73.7 MB)   | tok2vec, tagger, morphologizer, parser, ner | CPU-optimized Tagalog NLP model. Pretrained using the TLUnified dataset. Using floret vectors (50k keys)     |
+| tl_calamancy_lg (431.9 MB)  | tok2vec, tagger, morphologizer, parser, ner | CPU-optimized large Tagalog NLP model. Pretrained using the TLUnified dataset. Using fastText vectors (714k) |
+| tl_calamancy_trf (775.6 MB) | transformer, tagger, parser, ner            | GPU-optimized transformer Tagalog NLP model. Uses roberta-tagalog-base as context vectors.                   |
+
+## Data sources
 
 
 ## 📋 project.yml
@@ -53,13 +59,15 @@ Commands are only re-run if their inputs have changed.
 | `train-vectors-lg` | Train large-sized word vectors (200 dims, 200k keys) using the floret binary. |
 | `pretrain-md` | Pretrain with information from raw text using floret (md) vectors |
 | `pretrain-lg` | Pretrain with information from raw text using fastText vectors |
-| `train-parser-tagger` | Train the parser and tagger components using the Universal Dependencies Ugnayan Treebank |
+| `train-parser-tagger-md` | Train the parser and tagger components using the Universal Dependencies Ugnayan Treebank |
 | `train-ner-md` | Train NER component of tl_calamancy_md using floret vectors with pretraining (50k unique vectors) |
+| `assemble-md` | Assemble the tl_calamancy_md model and package it as a spaCy pipeline |
+| `train-parser-tagger-lg` | Train the parser and tagger components using the Universal Dependencies Ugnayan Treebank |
 | `train-ner-lg` | Train NER component of tl_calamancy_lg using fastText vectors with pretraining (714k unique keys) |
+| `assemble-lg` | Assemble the tl_calamancy_lg model and package it as a spaCy pipeline |
+| `train-parser-tagger-trf` | Train the parser and tagger components using the Universal Dependencies Ugnayan Treebank |
 | `train-ner-trf` | Train NER component of tl_calamancy_trf using context-sensitive vectors from roberta-tagalog |
 | `assemble-trf` | Assemble the tl_calamancy_trf model and package it as a spaCy pipeline |
-| `assemble-lg` | Assemble the tl_calamancy_lg model and package it as a spaCy pipeline |
-| `assemble-md` | Assemble the tl_calamancy_md model and package it as a spaCy pipeline |
 
 ### ⏭ Workflows
 
@@ -71,9 +79,9 @@ inputs have changed.
 | Workflow | Steps |
 | --- | --- |
 | `setup` | `setup-training-data` &rarr; `setup-pretraining-data` &rarr; `setup-fasttext-vectors` &rarr; `build-floret` |
-| `tl-calamancy-trf` | `train-parser-tagger` &rarr; `train-ner-trf` &rarr; `assemble-trf` |
-| `tl-calamancy-lg` | `pretrain-lg` &rarr; `train-vectors-lg` &rarr; `train-parser-tagger` &rarr; `train-ner-lg` &rarr; `assemble-lg` |
-| `tl-calamancy-md` | `pretrain-md` &rarr; `train-vectors-md` &rarr; `train-parser-tagger` &rarr; `train-ner-md` &rarr; `assemble-md` |
+| `tl-calamancy-trf` | `train-parser-tagger-trf` &rarr; `train-ner-trf` &rarr; `assemble-trf` |
+| `tl-calamancy-lg` | `pretrain-lg` &rarr; `train-vectors-lg` &rarr; `train-parser-tagger-lg` &rarr; `train-ner-lg` &rarr; `assemble-lg` |
+| `tl-calamancy-md` | `pretrain-md` &rarr; `train-vectors-md` &rarr; `train-parser-tagger-md` &rarr; `train-ner-md` &rarr; `assemble-md` |
 
 ### 🗂 Assets
 
@@ -84,7 +92,8 @@ in the project directory.
 | File | Source | Description |
 | --- | --- | --- |
 | `assets/corpus.tar.gz` | URL | Annotated TLUnified corpora in spaCy format with train, dev, and test splits. |
-| `assets/treebank` | Git | Treebank data for UD_Tagalog-Ugnayan |
+| `assets/treebank/UD_Tagalog-Ugnayan/` | Git | Treebank data for UD_Tagalog-Ugnayan |
+| `assets/treebank/UD_Tagalog-TRG/` | Git | Treebank data for UD_Tagalog-TRG |
 | `assets/fasttext.tl.gz` | URL | Tagalog fastText vectors provided from the fastText website (trained from CommonCrawl and Wikipedia). |
 | `assets/tlunified.zip` | URL | TLUnified dataset (from Improving Large-scale Language Models and Resources for Filipino by Cruz and Cheng 2022). |
 | `assets/floret` | Git | Floret repository for training floret and fastText models. |

--- a/models/v0.1.0/README.md
+++ b/models/v0.1.0/README.md
@@ -1,0 +1,50 @@
+<!-- SPACY PROJECT: AUTO-GENERATED DOCS START (do not remove) -->
+
+# 🪐 spaCy Project: Release v0.1.0
+
+This is a spaCy project that trains the v0.1.0 models for calamanCy.
+
+
+## 📋 project.yml
+
+The [`project.yml`](project.yml) defines the data assets required by the
+project, as well as the available commands and workflows. For details, see the
+[spaCy projects documentation](https://spacy.io/usage/projects).
+
+### ⏯ Commands
+
+The following commands are defined by the project. They
+can be executed using [`spacy project run [name]`](https://spacy.io/api/cli#project-run).
+Commands are only re-run if their inputs have changed.
+
+| Command | Description |
+| --- | --- |
+| `setup` | Prepare the Tagalog corpora and word vectors |
+
+### ⏭ Workflows
+
+The following workflows are defined by the project. They
+can be executed using [`spacy project run [name]`](https://spacy.io/api/cli#project-run)
+and will run the specified commands in order. Commands are only re-run if their
+inputs have changed.
+
+| Workflow | Steps |
+| --- | --- |
+| `tl-calamancy-trf` | `setup` |
+| `tl-calamancy-lg` | `setup` |
+| `tl-calamancy-md` | `setup` |
+
+### 🗂 Assets
+
+The following assets are defined by the project. They can
+be fetched by running [`spacy project assets`](https://spacy.io/api/cli#project-assets)
+in the project directory.
+
+| File | Source | Description |
+| --- | --- | --- |
+| `assets/corpus.tar.gz` | URL | Annotated TLUnified corpora in spaCy format with train, dev, and test splits. |
+| `assets/vectors.tar.gz` | URL | spaCy-compatible fastText and floret vectors. |
+| `assets/fasttext.tl.gz` | URL | Tagalog fastText vectors provided from the fastText website (trained from CommonCrawl and Wikipedia). |
+| `assets/tl_tlunified_pt_chars.bin` | URL | Pretraining weights for Tagalog using spaCy's pretrain command (using 'characters' objective). |
+
+<!-- SPACY PROJECT: AUTO-GENERATED DOCS END (do not remove) -->

--- a/models/v0.1.0/README.md
+++ b/models/v0.1.0/README.md
@@ -28,6 +28,10 @@ python -m spacy project run tl-calamancy-md
 
 ## Model information
 
+The table below shows an overview of the calamanCy models in this project. For more information,
+I suggest checking the [language pipeline metadata](https://spacy.io/api/language#meta).
+
+
 | Model                       | Pipelines                                   | Description                                                                                                  |
 |-----------------------------|---------------------------------------------|--------------------------------------------------------------------------------------------------------------|
 | tl_calamancy_md (73.7 MB)   | tok2vec, tagger, morphologizer, parser, ner | CPU-optimized Tagalog NLP model. Pretrained using the TLUnified dataset. Using floret vectors (50k keys)     |
@@ -35,6 +39,16 @@ python -m spacy project run tl-calamancy-md
 | tl_calamancy_trf (775.6 MB) | transformer, tagger, parser, ner            | GPU-optimized transformer Tagalog NLP model. Uses roberta-tagalog-base as context vectors.                   |
 
 ## Data sources
+
+The table below shows the data sources used to train the pipelines. Note that the Ugnayan treebank
+is not licensed for commercial use while TLUnified is under GNU GPL. Please consider these licenses
+when using the calamanCy pipelines in your application.
+
+| Source                                                                                 | Authors                                          | License         |
+|----------------------------------------------------------------------------------------|--------------------------------------------------|-----------------|
+| [TLUnified Dataset](https://aclanthology.org/2022.lrec-1.703/)                         | Jan Christian Blaise Cruz and Charibeth Cheng    | GNU GPL 3.0     |
+| [UD_Tagalog-TRG](https://universaldependencies.org/treebanks/tl_trg/index.html)        | Stephanie Samson, Daniel Zeman, and Mary Ann Tan | CC BY-SA 3.0    |
+| [UD_Tagalog-Ugnayan](https://universaldependencies.org/treebanks/tl_ugnayan/index.html) | Angelina Aquino                                  | CC BY-NC_SA 4.0 |
 
 
 ## 📋 project.yml

--- a/models/v0.1.0/configs/assemble.cfg
+++ b/models/v0.1.0/configs/assemble.cfg
@@ -1,0 +1,34 @@
+[paths]
+parser_model = null
+ner_model = null
+
+[nlp]
+lang = "tl"
+pipeline = ["tok2vec", "tagger", "morphologizer", "parser", "ner"]
+tokenizer = {"@tokenizers":"spacy.Tokenizer.v1"}
+
+[initialize]
+vectors = ${paths.parser_model}
+
+[components]
+
+[components.tok2vec]
+source = ${paths.parser_model}
+component = "tok2vec"
+
+[components.tagger]
+source = ${paths.parser_model}
+component = "tagger"
+
+[components.morphologizer]
+source = ${paths.parser_model}
+component = "morphologizer"
+
+[components.parser]
+source = ${paths.parser_model}
+component = "parser"
+
+[components.ner]
+source = ${paths.ner_model}
+component = "ner"
+replace_listeners = ["model.tok2vec"]

--- a/models/v0.1.0/configs/assemble_trf.cfg
+++ b/models/v0.1.0/configs/assemble_trf.cfg
@@ -1,0 +1,31 @@
+[paths]
+parser_model = null
+ner_model = null
+
+[nlp]
+lang = "tl"
+pipeline = ["transformer", "tagger", "morphologizer", "parser", "ner"]
+tokenizer = {"@tokenizers":"spacy.Tokenizer.v1"}
+
+[components]
+
+[components.transformer]
+source = ${paths.parser_model}
+component = "transformer"
+
+[components.tagger]
+source = ${paths.parser_model}
+component = "tagger"
+
+[components.morphologizer]
+source = ${paths.parser_model}
+component = "morphologizer"
+
+[components.parser]
+source = ${paths.parser_model}
+component = "parser"
+
+[components.ner]
+source = ${paths.ner_model}
+component = "ner"
+replace_listeners = ["model.tok2vec"]

--- a/models/v0.1.0/configs/ner.cfg
+++ b/models/v0.1.0/configs/ner.cfg
@@ -1,0 +1,182 @@
+[paths]
+train = null
+dev = null
+vectors = null
+init_tok2vec = null
+raw_text = null
+
+[system]
+gpu_allocator = null
+seed = 0
+
+[nlp]
+lang = "tl"
+pipeline = ["tok2vec","ner"]
+batch_size = 1000
+disabled = []
+before_creation = null
+after_creation = null
+after_pipeline_creation = null
+tokenizer = {"@tokenizers":"spacy.Tokenizer.v1"}
+
+[components]
+
+[components.ner]
+factory = "ner"
+incorrect_spans_key = null
+moves = null
+scorer = {"@scorers":"spacy.ner_scorer.v1"}
+update_with_oracle_cut_size = 100
+
+[components.ner.model]
+@architectures = "spacy.TransitionBasedParser.v2"
+state_type = "ner"
+extra_state_tokens = false
+hidden_width = 64
+maxout_pieces = 2
+use_upper = true
+nO = null
+
+[components.ner.model.tok2vec]
+@architectures = "spacy.Tok2VecListener.v1"
+width = ${components.tok2vec.model.encode.width}
+upstream = "*"
+
+[components.tok2vec]
+factory = "tok2vec"
+
+[components.tok2vec.model]
+@architectures = "spacy.Tok2Vec.v2"
+
+[components.tok2vec.model.embed]
+@architectures = "spacy.MultiHashEmbed.v2"
+width = ${components.tok2vec.model.encode.width}
+attrs = ["NORM","PREFIX","SUFFIX","SHAPE"]
+rows = [5000,2500,2500,2500]
+include_static_vectors = true
+
+[components.tok2vec.model.encode]
+@architectures = "spacy.MaxoutWindowEncoder.v2"
+width = 256
+depth = 8
+window_size = 1
+maxout_pieces = 3
+
+[corpora]
+
+[corpora.dev]
+@readers = "spacy.Corpus.v1"
+path = ${paths.dev}
+max_length = 0
+gold_preproc = false
+limit = 0
+augmenter = null
+
+[corpora.pretrain]
+@readers = "spacy.JsonlCorpus.v1"
+path = ${paths.raw_text}
+min_length = 5
+max_length = 500
+limit = 0
+
+[corpora.train]
+@readers = "spacy.Corpus.v1"
+path = ${paths.train}
+max_length = 0
+gold_preproc = false
+limit = 0
+augmenter = null
+
+[training]
+dev_corpus = "corpora.dev"
+train_corpus = "corpora.train"
+seed = ${system.seed}
+gpu_allocator = ${system.gpu_allocator}
+dropout = 0.1
+accumulate_gradient = 1
+patience = 1600
+max_epochs = 0
+max_steps = 20000
+eval_frequency = 200
+frozen_components = []
+annotating_components = []
+before_to_disk = null
+
+[training.batcher]
+@batchers = "spacy.batch_by_words.v1"
+discard_oversize = false
+tolerance = 0.2
+get_length = null
+
+[training.batcher.size]
+@schedules = "compounding.v1"
+start = 100
+stop = 1000
+compound = 1.001
+t = 0.0
+
+[training.logger]
+@loggers = "spacy.ConsoleLogger.v1"
+progress_bar = false
+
+[training.optimizer]
+@optimizers = "Adam.v1"
+beta1 = 0.9
+beta2 = 0.999
+L2_is_weight_decay = true
+L2 = 0.01
+grad_clip = 1.0
+use_averages = false
+eps = 0.00000001
+learn_rate = 0.001
+
+[training.score_weights]
+ents_f = 1.0 
+ents_p = 0.0
+ents_r = 0.0
+ents_per_type = null
+
+[pretraining]
+max_epochs = 1000
+dropout = 0.2
+n_save_every = null
+n_save_epoch = 5
+component = "tok2vec"
+layer = ""
+corpus = "corpora.pretrain"
+
+[pretraining.batcher]
+@batchers = "spacy.batch_by_words.v1"
+size = 3000
+discard_oversize = false
+tolerance = 0.2
+get_length = null
+
+[pretraining.objective]
+@architectures = "spacy.PretrainCharacters.v1"
+maxout_pieces = 3
+hidden_size = 300
+n_characters = 4
+
+[pretraining.optimizer]
+@optimizers = "Adam.v1"
+beta1 = 0.9
+beta2 = 0.999
+L2_is_weight_decay = true
+L2 = 0.01
+grad_clip = 1.0
+use_averages = true
+eps = 0.00000001
+learn_rate = 0.001
+
+[initialize]
+vectors = ${paths.vectors}
+init_tok2vec = ${paths.init_tok2vec}
+vocab_data = null
+lookups = null
+before_init = null
+after_init = null
+
+[initialize.components]
+
+[initialize.tokenizer]

--- a/models/v0.1.0/configs/ner_trf.cfg
+++ b/models/v0.1.0/configs/ner_trf.cfg
@@ -3,16 +3,15 @@ train = null
 dev = null
 vectors = null
 init_tok2vec = null
-raw_text = null
 
 [system]
-gpu_allocator = null
+gpu_allocator = "pytorch"
 seed = 0
 
 [nlp]
 lang = "tl"
-pipeline = ["tok2vec","ner"]
-batch_size = 1000
+pipeline = ["transformer","ner"]
+batch_size = 128
 disabled = []
 before_creation = null
 after_creation = null
@@ -34,33 +33,36 @@ state_type = "ner"
 extra_state_tokens = false
 hidden_width = 64
 maxout_pieces = 2
-use_upper = true
+use_upper = false
 nO = null
 
 [components.ner.model.tok2vec]
-@architectures = "spacy.Tok2VecListener.v1"
-width = ${components.tok2vec.model.encode.width}
+@architectures = "spacy-transformers.TransformerListener.v1"
+grad_factor = 1.0
+pooling = {"@layers":"reduce_mean.v1"}
 upstream = "*"
 
-[components.tok2vec]
-factory = "tok2vec"
+[components.transformer]
+factory = "transformer"
+max_batch_items = 4096
+set_extra_annotations = {"@annotation_setters":"spacy-transformers.null_annotation_setter.v1"}
 
-[components.tok2vec.model]
-@architectures = "spacy.Tok2Vec.v2"
+[components.transformer.model]
+@architectures = "spacy-transformers.TransformerModel.v3"
+name = "jcblaise/roberta-tagalog-base"
+mixed_precision = false
 
-[components.tok2vec.model.embed]
-@architectures = "spacy.MultiHashEmbed.v2"
-width = ${components.tok2vec.model.encode.width}
-attrs = ["NORM","PREFIX","SUFFIX","SHAPE"]
-rows = [5000,2500,2500,2500]
-include_static_vectors = true
+[components.transformer.model.get_spans]
+@span_getters = "spacy-transformers.strided_spans.v1"
+window = 128
+stride = 96
 
-[components.tok2vec.model.encode]
-@architectures = "spacy.MaxoutWindowEncoder.v2"
-width = 256
-depth = 8
-window_size = 1
-maxout_pieces = 3
+[components.transformer.model.grad_scaler_config]
+
+[components.transformer.model.tokenizer_config]
+use_fast = true
+
+[components.transformer.model.transformer_config]
 
 [corpora]
 
@@ -72,13 +74,6 @@ gold_preproc = false
 limit = 0
 augmenter = null
 
-[corpora.pretrain]
-@readers = "spacy.JsonlCorpus.v1"
-path = ${paths.raw_text}
-min_length = 5
-max_length = 500
-limit = 0
-
 [corpora.train]
 @readers = "spacy.Corpus.v1"
 path = ${paths.train}
@@ -88,12 +83,12 @@ limit = 0
 augmenter = null
 
 [training]
+accumulate_gradient = 3
 dev_corpus = "corpora.dev"
 train_corpus = "corpora.train"
 seed = ${system.seed}
 gpu_allocator = ${system.gpu_allocator}
 dropout = 0.1
-accumulate_gradient = 1
 patience = 1600
 max_epochs = 0
 max_steps = 20000
@@ -103,17 +98,11 @@ annotating_components = []
 before_to_disk = null
 
 [training.batcher]
-@batchers = "spacy.batch_by_words.v1"
-discard_oversize = false
-tolerance = 0.2
+@batchers = "spacy.batch_by_padded.v1"
+discard_oversize = true
+size = 2000
+buffer = 256
 get_length = null
-
-[training.batcher.size]
-@schedules = "compounding.v1"
-start = 100
-stop = 1000
-compound = 1.001
-t = 0.0
 
 [training.logger]
 @loggers = "spacy.ConsoleLogger.v1"
@@ -128,46 +117,20 @@ L2 = 0.01
 grad_clip = 1.0
 use_averages = false
 eps = 0.00000001
-learn_rate = 0.001
+
+[training.optimizer.learn_rate]
+@schedules = "warmup_linear.v1"
+warmup_steps = 250
+total_steps = 20000
+initial_rate = 0.00005
 
 [training.score_weights]
-ents_f = 1.0 
+ents_f = 1.0
 ents_p = 0.0
 ents_r = 0.0
 ents_per_type = null
 
 [pretraining]
-max_epochs = 3
-dropout = 0.2
-n_save_every = 1
-n_save_epoch = 3
-component = "tok2vec"
-layer = ""
-corpus = "corpora.pretrain"
-
-[pretraining.batcher]
-@batchers = "spacy.batch_by_words.v1"
-size = 3000
-discard_oversize = false
-tolerance = 0.2
-get_length = null
-
-[pretraining.objective]
-@architectures = "spacy.PretrainCharacters.v1"
-maxout_pieces = 3
-hidden_size = 300
-n_characters = 4
-
-[pretraining.optimizer]
-@optimizers = "Adam.v1"
-beta1 = 0.9
-beta2 = 0.999
-L2_is_weight_decay = true
-L2 = 0.01
-grad_clip = 1.0
-use_averages = true
-eps = 0.00000001
-learn_rate = 0.001
 
 [initialize]
 vectors = ${paths.vectors}

--- a/models/v0.1.0/configs/parser_tagger.cfg
+++ b/models/v0.1.0/configs/parser_tagger.cfg
@@ -3,7 +3,6 @@ train = null
 dev = null
 vectors = null
 init_tok2vec = null
-raw_text = null
 
 [system]
 gpu_allocator = null
@@ -11,33 +10,57 @@ seed = 0
 
 [nlp]
 lang = "tl"
-pipeline = ["tok2vec","ner"]
-batch_size = 1000
+pipeline = ["tok2vec","tagger","morphologizer","parser"]
+tokenizer = {"@tokenizers":"spacy.Tokenizer.v1"}
 disabled = []
 before_creation = null
 after_creation = null
 after_pipeline_creation = null
-tokenizer = {"@tokenizers":"spacy.Tokenizer.v1"}
+batch_size = 1000
 
 [components]
 
-[components.ner]
-factory = "ner"
-incorrect_spans_key = null
+[components.morphologizer]
+factory = "morphologizer"
+
+[components.morphologizer.model]
+@architectures = "spacy.Tagger.v1"
+nO = null
+
+[components.morphologizer.model.tok2vec]
+@architectures = "spacy.Tok2VecListener.v1"
+width = ${components.tok2vec.model.encode.width}
+upstream = "*"
+
+[components.parser]
+factory = "parser"
+learn_tokens = false
+min_action_freq = 30
 moves = null
-scorer = {"@scorers":"spacy.ner_scorer.v1"}
 update_with_oracle_cut_size = 100
 
-[components.ner.model]
+[components.parser.model]
 @architectures = "spacy.TransitionBasedParser.v2"
-state_type = "ner"
+state_type = "parser"
 extra_state_tokens = false
-hidden_width = 64
-maxout_pieces = 2
+hidden_width = 128
+maxout_pieces = 3
 use_upper = true
 nO = null
 
-[components.ner.model.tok2vec]
+[components.parser.model.tok2vec]
+@architectures = "spacy.Tok2VecListener.v1"
+width = ${components.tok2vec.model.encode.width}
+upstream = "*"
+
+[components.tagger]
+factory = "tagger"
+
+[components.tagger.model]
+@architectures = "spacy.Tagger.v1"
+nO = null
+
+[components.tagger.model.tok2vec]
 @architectures = "spacy.Tok2VecListener.v1"
 width = ${components.tok2vec.model.encode.width}
 upstream = "*"
@@ -49,16 +72,16 @@ factory = "tok2vec"
 @architectures = "spacy.Tok2Vec.v2"
 
 [components.tok2vec.model.embed]
-@architectures = "spacy.MultiHashEmbed.v2"
+@architectures = "spacy.MultiHashEmbed.v1"
 width = ${components.tok2vec.model.encode.width}
-attrs = ["NORM","PREFIX","SUFFIX","SHAPE"]
+attrs = ["LOWER","PREFIX","SUFFIX","SHAPE"]
 rows = [5000,2500,2500,2500]
-include_static_vectors = true
+include_static_vectors = false
 
 [components.tok2vec.model.encode]
 @architectures = "spacy.MaxoutWindowEncoder.v2"
-width = 256
-depth = 8
+width = 96
+depth = 4
 window_size = 1
 maxout_pieces = 3
 
@@ -72,17 +95,10 @@ gold_preproc = false
 limit = 0
 augmenter = null
 
-[corpora.pretrain]
-@readers = "spacy.JsonlCorpus.v1"
-path = ${paths.raw_text}
-min_length = 5
-max_length = 500
-limit = 0
-
 [corpora.train]
 @readers = "spacy.Corpus.v1"
 path = ${paths.train}
-max_length = 0
+max_length = 2000
 gold_preproc = false
 limit = 0
 augmenter = null
@@ -99,7 +115,6 @@ max_epochs = 0
 max_steps = 20000
 eval_frequency = 200
 frozen_components = []
-annotating_components = []
 before_to_disk = null
 
 [training.batcher]
@@ -131,43 +146,18 @@ eps = 0.00000001
 learn_rate = 0.001
 
 [training.score_weights]
-ents_f = 1.0 
-ents_p = 0.0
-ents_r = 0.0
-ents_per_type = null
+morph_per_feat = null
+dep_las_per_type = null
+sents_p = null
+sents_r = null
+tag_acc = 0.33
+pos_acc = 0.17
+morph_acc = 0.17
+dep_uas = 0.17
+dep_las = 0.17
+sents_f = 0.0
 
 [pretraining]
-max_epochs = 3
-dropout = 0.2
-n_save_every = 1
-n_save_epoch = 3
-component = "tok2vec"
-layer = ""
-corpus = "corpora.pretrain"
-
-[pretraining.batcher]
-@batchers = "spacy.batch_by_words.v1"
-size = 3000
-discard_oversize = false
-tolerance = 0.2
-get_length = null
-
-[pretraining.objective]
-@architectures = "spacy.PretrainCharacters.v1"
-maxout_pieces = 3
-hidden_size = 300
-n_characters = 4
-
-[pretraining.optimizer]
-@optimizers = "Adam.v1"
-beta1 = 0.9
-beta2 = 0.999
-L2_is_weight_decay = true
-L2 = 0.01
-grad_clip = 1.0
-use_averages = true
-eps = 0.00000001
-learn_rate = 0.001
 
 [initialize]
 vectors = ${paths.vectors}

--- a/models/v0.1.0/configs/parser_tagger_trf.cfg
+++ b/models/v0.1.0/configs/parser_tagger_trf.cfg
@@ -1,0 +1,187 @@
+[paths]
+train = null
+dev = null
+vectors = null
+init_tok2vec = null
+
+[system]
+gpu_allocator = "pytorch"
+seed = 0
+
+[nlp]
+lang = "tl"
+pipeline = ["transformer","tagger","morphologizer","parser"]
+batch_size = 128
+disabled = []
+before_creation = null
+after_creation = null
+after_pipeline_creation = null
+tokenizer = {"@tokenizers":"spacy.Tokenizer.v1"}
+
+[components]
+
+[components.morphologizer]
+factory = "morphologizer"
+extend = false
+overwrite = true
+scorer = {"@scorers":"spacy.morphologizer_scorer.v1"}
+
+[components.morphologizer.model]
+@architectures = "spacy.Tagger.v2"
+nO = null
+normalize = false
+
+[components.morphologizer.model.tok2vec]
+@architectures = "spacy-transformers.TransformerListener.v1"
+grad_factor = 1.0
+pooling = {"@layers":"reduce_mean.v1"}
+upstream = "*"
+
+[components.parser]
+factory = "parser"
+learn_tokens = false
+min_action_freq = 30
+moves = null
+scorer = {"@scorers":"spacy.parser_scorer.v1"}
+update_with_oracle_cut_size = 100
+
+[components.parser.model]
+@architectures = "spacy.TransitionBasedParser.v2"
+state_type = "parser"
+extra_state_tokens = false
+hidden_width = 128
+maxout_pieces = 3
+use_upper = false
+nO = null
+
+[components.parser.model.tok2vec]
+@architectures = "spacy-transformers.TransformerListener.v1"
+grad_factor = 1.0
+pooling = {"@layers":"reduce_mean.v1"}
+upstream = "*"
+
+[components.tagger]
+factory = "tagger"
+neg_prefix = "!"
+overwrite = false
+scorer = {"@scorers":"spacy.tagger_scorer.v1"}
+
+[components.tagger.model]
+@architectures = "spacy.Tagger.v2"
+nO = null
+normalize = false
+
+[components.tagger.model.tok2vec]
+@architectures = "spacy-transformers.TransformerListener.v1"
+grad_factor = 1.0
+pooling = {"@layers":"reduce_mean.v1"}
+upstream = "*"
+
+[components.transformer]
+factory = "transformer"
+max_batch_items = 4096
+set_extra_annotations = {"@annotation_setters":"spacy-transformers.null_annotation_setter.v1"}
+
+[components.transformer.model]
+@architectures = "spacy-transformers.TransformerModel.v3"
+name = "jcblaise/roberta-tagalog-base"
+mixed_precision = false
+
+[components.transformer.model.get_spans]
+@span_getters = "spacy-transformers.strided_spans.v1"
+window = 128
+stride = 96
+
+[components.transformer.model.grad_scaler_config]
+
+[components.transformer.model.tokenizer_config]
+use_fast = true
+
+[components.transformer.model.transformer_config]
+
+[corpora]
+
+[corpora.dev]
+@readers = "spacy.Corpus.v1"
+path = ${paths.dev}
+max_length = 0
+gold_preproc = false
+limit = 0
+augmenter = null
+
+[corpora.train]
+@readers = "spacy.Corpus.v1"
+path = ${paths.train}
+max_length = 0
+gold_preproc = false
+limit = 0
+augmenter = null
+
+[training]
+accumulate_gradient = 3
+dev_corpus = "corpora.dev"
+train_corpus = "corpora.train"
+seed = ${system.seed}
+gpu_allocator = ${system.gpu_allocator}
+dropout = 0.1
+patience = 1600
+max_epochs = 0
+max_steps = 20000
+eval_frequency = 200
+frozen_components = []
+annotating_components = []
+before_to_disk = null
+before_update = null
+
+[training.batcher]
+@batchers = "spacy.batch_by_padded.v1"
+discard_oversize = true
+size = 2000
+buffer = 256
+get_length = null
+
+[training.logger]
+@loggers = "spacy.ConsoleLogger.v1"
+progress_bar = false
+
+[training.optimizer]
+@optimizers = "Adam.v1"
+beta1 = 0.9
+beta2 = 0.999
+L2_is_weight_decay = true
+L2 = 0.01
+grad_clip = 1.0
+use_averages = false
+eps = 0.00000001
+
+[training.optimizer.learn_rate]
+@schedules = "warmup_linear.v1"
+warmup_steps = 250
+total_steps = 20000
+initial_rate = 0.00005
+
+[training.score_weights]
+tag_acc = 0.33
+pos_acc = 0.17
+morph_acc = 0.17
+morph_per_feat = null
+dep_uas = 0.17
+dep_las = 0.17
+dep_las_per_type = null
+sents_p = null
+sents_r = null
+sents_f = 0.0
+
+[pretraining]
+
+[initialize]
+vectors = ${paths.vectors}
+init_tok2vec = ${paths.init_tok2vec}
+vocab_data = null
+lookups = null
+before_init = null
+after_init = null
+
+[initialize.components]
+
+[initialize.tokenizer]

--- a/models/v0.1.0/meta.json
+++ b/models/v0.1.0/meta.json
@@ -1,0 +1,35 @@
+{
+    "name": "tl_calamancy",
+    "lang": "tl",
+    "version": "0.1.0",
+    "spacy_version": ">=3.5.0",
+    "parent_package": "spacy",
+    "requirements": [
+        "spacy-transformers>=1.2.0"
+    ],
+    "description": "calamanCy: Tagalog NLP pipelines in spaCy",
+    "author": "Lester James V. Miranda",
+    "email": "ljvmiranda@gmail.com",
+    "url": "https://github.com/ljvmiranda921/calamanCy",
+    "license": "CC BY-SA 3.0",
+    "sources": [
+        {
+            "name": "TLUnified dataset",
+            "license": "GNU GPL 3.0",
+            "author": "Jan Christian Blaise Cruz and Charibeth Cheng",
+            "url": "https://aclanthology.org/2022.lrec-1.703/"
+        },
+        {
+            "name": "UD_Tagalog-TRG",
+            "license": "CC BY-SA 3.0",
+            "author": "Stephanie Samson, Daniel Zeman, and Mary Ann C. Tan",
+            "url": "https://universaldependencies.org/treebanks/tl_trg/index.html"
+        },
+        {
+            "name": "UD_Tagalog-Ugnayan",
+            "license": "CC BY-NC-SA 4.0",
+            "author": "Angelina Aquino",
+            "url": "https://universaldependencies.org/treebanks/tl_ugnayan/index.html"
+        }
+    ]
+}

--- a/models/v0.1.0/project.yml
+++ b/models/v0.1.0/project.yml
@@ -1,0 +1,222 @@
+title: "Release v0.1.0"
+description: |
+  This is a spaCy project that trains the v0.1.0 models for calamanCy.
+
+vars:
+  # Versioning
+  version: v0.1.0
+  dataset_version: 1.0
+  pretrain_epoch: 5
+  # Training
+  lang: "tl"
+  gpu_id: 0
+
+directories:
+  - "assets"
+  - "configs"
+  - "corpus"
+  - "scripts"
+  - "training"
+
+assets:
+  - dest: assets/corpus.tar.gz
+    url: "https://storage.googleapis.com/ljvmiranda/calamanCy/tl_tlunified_gold/v${vars.dataset_version}/corpus.tar.gz"
+    description: "Annotated TLUnified corpora in spaCy format with train, dev, and test splits."
+  - dest: "assets/treebank"
+    description: "Treebank data for UD_Tagalog-Ugnayan"
+    git:
+      repo: "https://github.com/UniversalDependencies/UD_Tagalog-Ugnayan"
+      branch: "master"
+      path: ""
+  - dest: "assets/fasttext.tl.gz"
+    url: "https://dl.fbaipublicfiles.com/fasttext/vectors-crawl/cc.tl.300.vec.gz"
+    description: "Tagalog fastText vectors provided from the fastText website (trained from CommonCrawl and Wikipedia)."
+    extra: True
+  - dest: "assets/tlunified.zip"
+    url: "https://s3.us-east-2.amazonaws.com/blaisecruz.com/datasets/tlunified/tlunified.zip"
+    description: "TLUnified dataset (from Improving Large-scale Language Models and Resources for Filipino by Cruz and Cheng 2022)."
+  - dest: "assets/floret"
+    git:
+      repo: "https://github.com/explosion/floret"
+      branch: "main"
+      path: ""
+    description: "Floret repository for training floret and fastText models."
+
+workflows:
+  setup:
+    - "setup-training-data"
+    - "setup-pretraining-data"
+    - "setup-fasttext-vectors"
+    - "build-floret"
+  tl-calamancy-trf:
+    - "train-parser-tagger"
+    - "train-ner-trf"
+    - "assemble-trf"
+    - "package"
+  tl-calamancy-lg:
+    - "pretrain"
+    - "train-vectors-lg"
+    - "train-parser-tagger"
+    - "train-ner-lg"
+    - "assemble-lg"
+    - "package"
+  tl-calamancy-md:
+    - "pretrain"
+    - "train-vectors-md"
+    - "train-parser-tagger"
+    - "train-ner-md"
+    - "assemble-md"
+    - "package"
+
+commands:
+  - name: "setup-training-data"
+    help: "Prepare the Tagalog corpora used for training various spaCy components"
+    script:
+      # ner: Extract Tagalog corpora
+      - "tar -xzvf assets/corpus.tar.gz -C corpus/"
+      # parser, tagger: Convert treebank into spaCy format
+      - "mkdir -p corpus/treebank/"
+      - >-
+        python -m spacy convert 
+        assets/treebank/tl_ugnayan-ud-test.conllu corpus/treebank
+        --converter conllu
+        --n-sents 1
+        --merge-subtokens
+    deps:
+      - assets/corpus.tar.gz
+      - assets/treebank/tl_ugnayan-ud-test.conllu
+    outputs:
+      - corpus/train.spacy
+      - corpus/dev.spacy
+      - corpus/test.spacy
+      - corpus/tl_ugnayan-ud-test.spacy
+
+  - name: "setup-pretraining-data"
+    help: "Prepare the Tagalog corpora used for self-supervised learning operations"
+    script:
+      - unzip -o assets/tlunified.zip -d assets/
+    outputs:
+      - assets/tlunified/train.txt
+
+  - name: "setup-fasttext-vectors"
+    help: "Make fastText vectors spaCy compatible"
+    script:
+      - "gzip -d -f assets/fasttext.tl.gz"
+      - >-
+        python -m spacy init vectors
+        tl assets/fasttext.tl vectors/fasttext-tl
+    outputs:
+      - vectors/fasttext-tl
+
+  - name: "train-vectors-lg"
+    help: "Train large-sized word vectors (200 dims, 200k keys) using the floret binary."
+    script:
+      - mkdir -p assets/vectors/floret-tl-lg/
+      - >-
+        assets/floret/floret skipgram
+        -input assets/tlunified/train.txt 
+        -output assets/vectors/floret-tl-lg/vectors
+        -dim 200
+        -minn 3
+        -maxn 5 
+        -mode floret
+        -hashCount 2
+        -bucket 200000
+      - >-
+        python -m spacy init vectors 
+        tl assets/floret-tl-lg/vectors.floret vectors/floret-tl-lg
+        --mode floret
+    deps:
+      - assets/floret/floret
+    outputs:
+      - vectors/floret-tl-lg
+
+  - name: "train-vectors-md"
+    help: "Train medium-sized word vectors (200 dims, 50k keys) using the floret binary."
+    script:
+      - mkdir -p assets/vectors/floret-tl-md/
+      - >-
+        assets/floret/floret skipgram
+        -input assets/tlunified/train.txt 
+        -output assets/vectors/floret-tl-md/vectors
+        -dim 200
+        -minn 3
+        -maxn 5 
+        -mode floret
+        -hashCount 2
+        -bucket 50000
+      - >-
+        python -m spacy init vectors 
+        tl assets/floret-tl-md/vectors.floret vectors/floret-tl-md
+        --mode floret
+    deps:
+      - assets/floret/floret
+    outputs:
+      - vectors/floret-tl-md
+
+  - name: "build-floret"
+    help: "Build floret binary for training fastText / floret vectors"
+    script:
+      - make -C assets/floret
+      - chmod +x assets/floret/floret
+    deps:
+      - assets/floret
+    outputs:
+      - assets/floret/floret
+
+  - name: "train-parser-tagger"
+    help: "Train the parser and tagger components using the Universal Dependencies Ugnayan Treebank"
+    script:
+      - ls
+
+  - name: "train-ner-md"
+    help: "Train NER component of tl_calamancy_md using floret vectors with pretraining (50k unique vectors)"
+    script:
+      - >-
+        python -m spacy train
+        configs/ner.cfg
+        --nlp.lang ${vars.lang}
+        --output training/ner_md/
+        --paths.train corpus/train.spacy
+        --paths.dev corpus/dev.spacy
+        --initialize.init_tok2vec assets/tl_tlunified_pt_chars.bin
+        --paths.vectors vectors/floret-tl-md 
+        --gpu-id ${vars.gpu_id}
+    deps:
+      - corpus/train.spacy
+      - corpus/dev.spacy
+      - assets/tl_tlunified_pt_chars.bin
+      - vectors/floret-tl-md
+    outputs:
+      - training/ner_md/model-best
+
+  - name: "train-ner-lg"
+    help: "Train NER component of tl_calamancy_lg using fastText vectors with pretraining (714k unique keys)"
+    script:
+      - >-
+        python -m spacy train
+        configs/ner.cfg
+        --nlp.lang ${vars.lang}
+        --output training/ner_lg/
+        --paths.train corpus/train.spacy
+        --paths.dev corpus/dev.spacy
+        --initialize.init_tok2vec assets/tl_tlunified_pt_chars.bin
+        --paths.vectors vectors/fasttext-tl
+        --gpu-id ${vars.gpu_id}
+    deps:
+      - corpus/train.spacy
+      - corpus/dev.spacy
+      - assets/tl_tlunified_pt_chars.bin
+      - vectors/fasttext-tl
+    outputs:
+      - training/ner_lg/model-best
+
+  - name: "train-ner-trf"
+    help: "Train NER component of tl_calamancy_trf using context-sensitive vectors from roberta-tagalog"
+    script:
+      - ls
+
+  - name: "package"
+    help: "Package the trained pipeline and prepare them for shipping"
+    script:
+      - ls

--- a/models/v0.1.0/project.yml
+++ b/models/v0.1.0/project.yml
@@ -44,6 +44,7 @@ remotes:
 
 directories:
   - "assets"
+  - "assets/treebank/"
   - "configs"
   - "corpus"
   - "scripts"
@@ -55,10 +56,16 @@ assets:
   - dest: assets/corpus.tar.gz
     description: "Annotated TLUnified corpora in spaCy format with train, dev, and test splits."
     url: "https://storage.googleapis.com/ljvmiranda/calamanCy/tl_tlunified_gold/v${vars.dataset_version}/corpus.tar.gz"
-  - dest: "assets/treebank"
+  - dest: "assets/treebank/UD_Tagalog-Ugnayan/"
     description: "Treebank data for UD_Tagalog-Ugnayan"
     git:
       repo: "https://github.com/UniversalDependencies/UD_Tagalog-Ugnayan"
+      branch: "master"
+      path: ""
+  - dest: "assets/treebank/UD_Tagalog-TRG/"
+    description: "Treebank data for UD_Tagalog-TRG"
+    git:
+      repo: "https://github.com/UniversalDependencies/UD_Tagalog-TRG"
       branch: "master"
       path: ""
   - dest: "assets/fasttext.tl.gz"
@@ -108,22 +115,34 @@ commands:
       - mkdir -p corpus/ner
       - "tar -xzvf assets/corpus.tar.gz -C corpus/ner"
       # parser, tagger: Convert treebank into spaCy format
+      # we are merging these two treebanks because the amount of data is too small
       - mkdir -p corpus/treebank/
       - >-
         python -m spacy convert 
-        assets/treebank/tl_ugnayan-ud-test.conllu assets/treebank
+        assets/treebank/UD_Tagalog-Ugnayan/tl_ugnayan-ud-test.conllu assets/treebank
         --converter conllu
         --n-sents 1
         --merge-subtokens
       - >-
+        python -m spacy convert 
+        assets/treebank/UD_Tagalog-TRG/tl_trg-ud-test.conllu assets/treebank
+        --converter conllu
+        --n-sents 1
+        --merge-subtokens
+      - >-
+        python -m scripts.merge_treebanks
+        assets/treebank/tl_trg-ud-test.spacy assets/treebank/tl_ugnayan-ud-test.spacy
+        assets/treebank/ud_merged.spacy
+      - >-
         python -m scripts.split_treebank
-        assets/treebank/tl_ugnayan-ud-test.spacy
+        assets/treebank/ud_merged.spacy
         corpus/treebank
         --lang ${vars.lang}
         --train-size 0.9
     deps:
       - assets/corpus.tar.gz
-      - assets/treebank/tl_ugnayan-ud-test.conllu
+      - assets/treebank/UD_Tagalog-Ugnayan/tl_ugnayan-ud-test.conllu
+      - assets/treebank/UD_Tagalog-TRG/tl_trg-ud-test.conllu
     outputs:
       - corpus/ner/train.spacy
       - corpus/ner/dev.spacy

--- a/models/v0.1.0/project.yml
+++ b/models/v0.1.0/project.yml
@@ -1,15 +1,46 @@
 title: "Release v0.1.0"
 description: |
-  This is a spaCy project that trains the v0.1.0 models for calamanCy.
+  This is a spaCy project that trains the v0.1.0 models for calamanCy. You can
+  use this project to replicate the pipelines shipped by the project. First, you need to install the
+  required dependencies:
+
+  ```
+  pip install -r requirements.txt
+  ```
+
+  Then you need to download all the assets (corpora, static vectors, etc.) via:
+
+  ```
+  python -m spacy project assets
+  ```
+
+  Before training the pipelines, you first need to run the setup workflow. This step prepares the
+  corpora for training (or pretraining) and builds the necessary binaries for other downstream commands.
+
+  ```
+  python -m spacy project run setup
+  ```
+
+  You can then train a pipeline by passing its name to the spaCy project command. For example, if you wish to train
+  `tl_calamancy_md`, you can execute the corresponding workflow like so:
+
+  ```
+  python -m spacy project run tl-calamancy-md 
+  ```
 
 vars:
   # Versioning
   version: v0.1.0
   dataset_version: 1.0
-  pretrain_epoch: 5
+  pretrain_epochs: 3
   # Training
   lang: "tl"
   gpu_id: 0
+
+remotes:
+  # Create a service account, download a JSON key, and set the credentials path
+  # to GOOGLE_APPLICATION_CREDENTIALS env variable
+  gcs: "gs://ljvmiranda/calamanCy/training_cache/${vars.version}/"
 
 directories:
   - "assets"
@@ -17,11 +48,13 @@ directories:
   - "corpus"
   - "scripts"
   - "training"
+  - "pretraining"
+  - "vectors"
 
 assets:
   - dest: assets/corpus.tar.gz
-    url: "https://storage.googleapis.com/ljvmiranda/calamanCy/tl_tlunified_gold/v${vars.dataset_version}/corpus.tar.gz"
     description: "Annotated TLUnified corpora in spaCy format with train, dev, and test splits."
+    url: "https://storage.googleapis.com/ljvmiranda/calamanCy/tl_tlunified_gold/v${vars.dataset_version}/corpus.tar.gz"
   - dest: "assets/treebank"
     description: "Treebank data for UD_Tagalog-Ugnayan"
     git:
@@ -29,18 +62,20 @@ assets:
       branch: "master"
       path: ""
   - dest: "assets/fasttext.tl.gz"
-    url: "https://dl.fbaipublicfiles.com/fasttext/vectors-crawl/cc.tl.300.vec.gz"
     description: "Tagalog fastText vectors provided from the fastText website (trained from CommonCrawl and Wikipedia)."
-    extra: True
+    url: "https://dl.fbaipublicfiles.com/fasttext/vectors-crawl/cc.tl.300.vec.gz"
   - dest: "assets/tlunified.zip"
     url: "https://s3.us-east-2.amazonaws.com/blaisecruz.com/datasets/tlunified/tlunified.zip"
     description: "TLUnified dataset (from Improving Large-scale Language Models and Resources for Filipino by Cruz and Cheng 2022)."
   - dest: "assets/floret"
+    description: "Floret repository for training floret and fastText models."
     git:
       repo: "https://github.com/explosion/floret"
       branch: "main"
       path: ""
-    description: "Floret repository for training floret and fastText models."
+  - dest: "assets/tlunified_raw_text.jsonl"
+    description: "Pre-converted raw text from TLUnified in JSONL format (1.1 GB)."
+    url: "https://storage.googleapis.com/ljvmiranda/calamanCy/tlunified_raw_text.jsonl"
 
 workflows:
   setup:
@@ -52,44 +87,49 @@ workflows:
     - "train-parser-tagger"
     - "train-ner-trf"
     - "assemble-trf"
-    - "package"
   tl-calamancy-lg:
-    - "pretrain"
+    - "pretrain-lg"
     - "train-vectors-lg"
     - "train-parser-tagger"
     - "train-ner-lg"
     - "assemble-lg"
-    - "package"
   tl-calamancy-md:
-    - "pretrain"
+    - "pretrain-md"
     - "train-vectors-md"
     - "train-parser-tagger"
     - "train-ner-md"
     - "assemble-md"
-    - "package"
 
 commands:
   - name: "setup-training-data"
     help: "Prepare the Tagalog corpora used for training various spaCy components"
     script:
       # ner: Extract Tagalog corpora
-      - "tar -xzvf assets/corpus.tar.gz -C corpus/"
+      - mkdir -p corpus/ner
+      - "tar -xzvf assets/corpus.tar.gz -C corpus/ner"
       # parser, tagger: Convert treebank into spaCy format
-      - "mkdir -p corpus/treebank/"
+      - mkdir -p corpus/treebank/
       - >-
         python -m spacy convert 
-        assets/treebank/tl_ugnayan-ud-test.conllu corpus/treebank
+        assets/treebank/tl_ugnayan-ud-test.conllu assets/treebank
         --converter conllu
         --n-sents 1
         --merge-subtokens
+      - >-
+        python -m scripts.split_treebank
+        assets/treebank/tl_ugnayan-ud-test.spacy
+        corpus/treebank
+        --lang ${vars.lang}
+        --train-size 0.9
     deps:
       - assets/corpus.tar.gz
       - assets/treebank/tl_ugnayan-ud-test.conllu
     outputs:
-      - corpus/train.spacy
-      - corpus/dev.spacy
-      - corpus/test.spacy
-      - corpus/tl_ugnayan-ud-test.spacy
+      - corpus/ner/train.spacy
+      - corpus/ner/dev.spacy
+      - corpus/ner/test.spacy
+      - corpus/treebank/train.spacy
+      - corpus/treebank/dev.spacy
 
   - name: "setup-pretraining-data"
     help: "Prepare the Tagalog corpora used for self-supervised learning operations"
@@ -101,35 +141,25 @@ commands:
   - name: "setup-fasttext-vectors"
     help: "Make fastText vectors spaCy compatible"
     script:
-      - "gzip -d -f assets/fasttext.tl.gz"
+      - gzip -d -f assets/fasttext.tl.gz
+      - mkdir -p vectors/fasttext-tl
       - >-
         python -m spacy init vectors
         tl assets/fasttext.tl vectors/fasttext-tl
+    deps:
+      - assets/fasttext.tl.gz
     outputs:
       - vectors/fasttext-tl
 
-  - name: "train-vectors-lg"
-    help: "Train large-sized word vectors (200 dims, 200k keys) using the floret binary."
+  - name: "build-floret"
+    help: "Build floret binary for training fastText / floret vectors"
     script:
-      - mkdir -p assets/vectors/floret-tl-lg/
-      - >-
-        assets/floret/floret skipgram
-        -input assets/tlunified/train.txt 
-        -output assets/vectors/floret-tl-lg/vectors
-        -dim 200
-        -minn 3
-        -maxn 5 
-        -mode floret
-        -hashCount 2
-        -bucket 200000
-      - >-
-        python -m spacy init vectors 
-        tl assets/floret-tl-lg/vectors.floret vectors/floret-tl-lg
-        --mode floret
+      - make -C assets/floret
+      - chmod +x assets/floret/floret
     deps:
-      - assets/floret/floret
+      - assets/floret
     outputs:
-      - vectors/floret-tl-lg
+      - assets/floret/floret
 
   - name: "train-vectors-md"
     help: "Train medium-sized word vectors (200 dims, 50k keys) using the floret binary."
@@ -145,29 +175,88 @@ commands:
         -mode floret
         -hashCount 2
         -bucket 50000
+      - mkdir -p vectors/floret-tl-md
       - >-
         python -m spacy init vectors 
-        tl assets/floret-tl-md/vectors.floret vectors/floret-tl-md
+        tl assets/vectors/floret-tl-md/vectors.floret vectors/floret-tl-md
         --mode floret
     deps:
       - assets/floret/floret
     outputs:
       - vectors/floret-tl-md
 
-  - name: "build-floret"
-    help: "Build floret binary for training fastText / floret vectors"
+  - name: "train-vectors-lg"
+    help: "Train large-sized word vectors (200 dims, 200k keys) using the floret binary."
     script:
-      - make -C assets/floret
-      - chmod +x assets/floret/floret
+      - mkdir -p assets/vectors/floret-tl-lg/
+      - >-
+        assets/floret/floret skipgram
+        -input assets/tlunified/train.txt 
+        -output assets/vectors/floret-tl-lg/vectors
+        -dim 200
+        -minn 3
+        -maxn 5 
+        -mode floret
+        -hashCount 2
+        -bucket 200000
+      - mkdir -p vectors/floret-tl-lg
+      - >-
+        python -m spacy init vectors 
+        tl assets/vectors/floret-tl-lg/vectors.floret vectors/floret-tl-lg
+        --mode floret
     deps:
-      - assets/floret
-    outputs:
       - assets/floret/floret
+    outputs:
+      - vectors/floret-tl-lg
+
+  - name: "pretrain-md"
+    help: "Pretrain with information from raw text using floret (md) vectors"
+    script:
+      - >-
+        python -m spacy pretrain configs/ner.cfg pretraining/init-tok2vec-md/
+        --paths.raw_text assets/tlunified_raw_text.jsonl
+        --pretraining.max_epochs ${vars.pretrain_epochs}
+        --pretraining.n_save_every 1
+        --paths.vectors vectors/floret-tl-md
+        --gpu-id ${vars.gpu_id}
+    deps:
+      - assets/tlunified_raw_text.jsonl
+      - vectors/floret-tl-md
+    outputs:
+      - pretraining/init-tok2vec-md/model-last.bin
+
+  - name: "pretrain-lg"
+    help: "Pretrain with information from raw text using fastText vectors"
+    script:
+      - >-
+        python -m spacy pretrain configs/ner.cfg pretraining/init-tok2vec-lg/
+        --paths.raw_text assets/tlunified_raw_text.jsonl
+        --pretraining.max_epochs ${vars.pretrain_epochs}
+        --pretraining.n_save_every 1
+        --paths.vectors vectors/fasttext-tl
+        --gpu-id ${vars.gpu_id}
+    deps:
+      - assets/tlunified_raw_text.jsonl
+      - vectors/fasttext-tl
+    outputs:
+      - pretraining/init-tok2vec-lg/model-last.bin
 
   - name: "train-parser-tagger"
     help: "Train the parser and tagger components using the Universal Dependencies Ugnayan Treebank"
     script:
-      - ls
+      - >-
+        python -m spacy train
+        configs/parser_tagger.cfg
+        --output training/parser_tagger/
+        --nlp.lang ${vars.lang}
+        --paths.train corpus/treebank/train.spacy
+        --paths.dev corpus/treebank/dev.spacy
+        --gpu-id ${vars.gpu_id}
+    deps:
+      - corpus/treebank/train.spacy
+      - corpus/treebank/dev.spacy
+    outputs:
+      - training/parser_tagger/model-best
 
   - name: "train-ner-md"
     help: "Train NER component of tl_calamancy_md using floret vectors with pretraining (50k unique vectors)"
@@ -177,15 +266,15 @@ commands:
         configs/ner.cfg
         --nlp.lang ${vars.lang}
         --output training/ner_md/
-        --paths.train corpus/train.spacy
-        --paths.dev corpus/dev.spacy
-        --initialize.init_tok2vec assets/tl_tlunified_pt_chars.bin
+        --paths.train corpus/ner/train.spacy
+        --paths.dev corpus/ner/dev.spacy
+        --initialize.init_tok2vec pretraining/init-tok2vec-md/model-last.bin
         --paths.vectors vectors/floret-tl-md 
         --gpu-id ${vars.gpu_id}
     deps:
-      - corpus/train.spacy
-      - corpus/dev.spacy
-      - assets/tl_tlunified_pt_chars.bin
+      - corpus/ner/train.spacy
+      - corpus/ner/dev.spacy
+      - pretraining/init-tok2vec-md/model-last.bin
       - vectors/floret-tl-md
     outputs:
       - training/ner_md/model-best
@@ -198,15 +287,16 @@ commands:
         configs/ner.cfg
         --nlp.lang ${vars.lang}
         --output training/ner_lg/
-        --paths.train corpus/train.spacy
-        --paths.dev corpus/dev.spacy
-        --initialize.init_tok2vec assets/tl_tlunified_pt_chars.bin
+        --paths.train corpus/ner/train.spacy
+        --paths.dev corpus/ner/dev.spacy
+        --initialize.init_tok2vec pretraining/init-tok2vec-lg/model-last.bin
         --paths.vectors vectors/fasttext-tl
         --gpu-id ${vars.gpu_id}
     deps:
-      - corpus/train.spacy
-      - corpus/dev.spacy
+      - corpus/ner/train.spacy
+      - corpus/ner/dev.spacy
       - assets/tl_tlunified_pt_chars.bin
+      - pretraining/init-tok2vec-lg/model-last.bin
       - vectors/fasttext-tl
     outputs:
       - training/ner_lg/model-best
@@ -214,9 +304,32 @@ commands:
   - name: "train-ner-trf"
     help: "Train NER component of tl_calamancy_trf using context-sensitive vectors from roberta-tagalog"
     script:
+      - >-
+        python -m spacy train
+        configs/ner_trf.cfg
+        --nlp.lang ${vars.lang}
+        --output training/ner_trf/
+        --components.transformer.model.name jcblaise/roberta-tagalog-base 
+        --paths.train corpus/ner/train.spacy
+        --paths.dev corpus/ner/dev.spacy
+        --gpu-id ${vars.gpu_id}
+    deps:
+      - corpus/ner/train.spacy
+      - corpus/ner/dev.spacy
+    outputs:
+      - training/ner_trf/model-best
+
+  - name: "assemble-trf"
+    help: "Assemble the tl_calamancy_trf model and package it as a spaCy pipeline"
+    script:
       - ls
 
-  - name: "package"
-    help: "Package the trained pipeline and prepare them for shipping"
+  - name: "assemble-lg"
+    help: "Assemble the tl_calamancy_lg model and package it as a spaCy pipeline"
+    script:
+      - ls
+
+  - name: "assemble-md"
+    help: "Assemble the tl_calamancy_md model and package it as a spaCy pipeline"
     script:
       - ls

--- a/models/v0.1.0/project.yml
+++ b/models/v0.1.0/project.yml
@@ -1,36 +1,56 @@
 title: "Release v0.1.0"
 description: |
   This is a spaCy project that trains the v0.1.0 models for calamanCy. You can
-  use this project to replicate the pipelines shipped by the project. First, you need to install the
-  required dependencies:
+  use this project to replicate the pipelines shipped by the project. First, you
+  need to install the required dependencies:
 
   ```
   pip install -r requirements.txt
   ```
 
-  Then you need to download all the assets (corpora, static vectors, etc.) via:
+  Then run the set-up commands:
 
   ```
   python -m spacy project assets
-  ```
-
-  Before training the pipelines, you first need to run the setup workflow. This step prepares the
-  corpora for training (or pretraining) and builds the necessary binaries for other downstream commands.
-
-  ```
   python -m spacy project run setup
   ```
 
-  You can then train a pipeline by passing its name to the spaCy project command. For example, if you wish to train
-  `tl_calamancy_md`, you can execute the corresponding workflow like so:
+  This step downloads all assets and prepares all the datasets and binaries for
+  training use.  You can then train a pipeline by passing its name to the spaCy
+  project command. For example, if you wish to train `tl_calamancy_md`, you can
+  execute the corresponding workflow like so:
 
   ```
   python -m spacy project run tl-calamancy-md 
   ```
 
+  ## Model information
+
+  The table below shows an overview of the calamanCy models in this project. For more information,
+  I suggest checking the [language pipeline metadata](https://spacy.io/api/language#meta).
+
+
+  | Model                       | Pipelines                                   | Description                                                                                                  |
+  |-----------------------------|---------------------------------------------|--------------------------------------------------------------------------------------------------------------|
+  | tl_calamancy_md (73.7 MB)   | tok2vec, tagger, morphologizer, parser, ner | CPU-optimized Tagalog NLP model. Pretrained using the TLUnified dataset. Using floret vectors (50k keys)     |
+  | tl_calamancy_lg (431.9 MB)  | tok2vec, tagger, morphologizer, parser, ner | CPU-optimized large Tagalog NLP model. Pretrained using the TLUnified dataset. Using fastText vectors (714k) |
+  | tl_calamancy_trf (775.6 MB) | transformer, tagger, parser, ner            | GPU-optimized transformer Tagalog NLP model. Uses roberta-tagalog-base as context vectors.                   |
+
+  ## Data sources
+
+  The table below shows the data sources used to train the pipelines. Note that the Ugnayan treebank
+  is not licensed for commercial use while TLUnified is under GNU GPL. Please consider these licenses
+  when using the calamanCy pipelines in your application.
+
+  | Source                                                                                 | Authors                                          | License         |
+  |----------------------------------------------------------------------------------------|--------------------------------------------------|-----------------|
+  | [TLUnified Dataset](https://aclanthology.org/2022.lrec-1.703/)                         | Jan Christian Blaise Cruz and Charibeth Cheng    | GNU GPL 3.0     |
+  | [UD_Tagalog-TRG](https://universaldependencies.org/treebanks/tl_trg/index.html)        | Stephanie Samson, Daniel Zeman, and Mary Ann Tan | CC BY-SA 3.0    |
+  | [UD_Tagalog-Ugnayan](https://universaldependencies.org/treebanks/tl_ugnayan/index.html) | Angelina Aquino                                  | CC BY-NC_SA 4.0 |
+
 vars:
   # Versioning
-  version: v0.1.0
+  version: 0.1.0
   dataset_version: 1.0
   pretrain_epochs: 3
   # Training
@@ -40,16 +60,17 @@ vars:
 remotes:
   # Create a service account, download a JSON key, and set the credentials path
   # to GOOGLE_APPLICATION_CREDENTIALS env variable
-  gcs: "gs://ljvmiranda/calamanCy/training_cache/${vars.version}/"
+  gcs: "gs://ljvmiranda/calamanCy/training_cache/v${vars.version}/"
 
 directories:
   - "assets"
   - "assets/treebank/"
   - "configs"
   - "corpus"
+  - "packages"
+  - "pretraining"
   - "scripts"
   - "training"
-  - "pretraining"
   - "vectors"
 
 assets:
@@ -91,19 +112,19 @@ workflows:
     - "setup-fasttext-vectors"
     - "build-floret"
   tl-calamancy-trf:
-    - "train-parser-tagger"
+    - "train-parser-tagger-trf"
     - "train-ner-trf"
     - "assemble-trf"
   tl-calamancy-lg:
     - "pretrain-lg"
     - "train-vectors-lg"
-    - "train-parser-tagger"
+    - "train-parser-tagger-lg"
     - "train-ner-lg"
     - "assemble-lg"
   tl-calamancy-md:
     - "pretrain-md"
     - "train-vectors-md"
-    - "train-parser-tagger"
+    - "train-parser-tagger-md"
     - "train-ner-md"
     - "assemble-md"
 
@@ -260,22 +281,23 @@ commands:
     outputs:
       - pretraining/init-tok2vec-lg/model-last.bin
 
-  - name: "train-parser-tagger"
+  - name: "train-parser-tagger-md"
     help: "Train the parser and tagger components using the Universal Dependencies Ugnayan Treebank"
     script:
       - >-
         python -m spacy train
         configs/parser_tagger.cfg
-        --output training/parser_tagger/
+        --output training/parser_tagger_md/
         --nlp.lang ${vars.lang}
         --paths.train corpus/treebank/train.spacy
         --paths.dev corpus/treebank/dev.spacy
+        --paths.vectors vectors/floret-tl-md
         --gpu-id ${vars.gpu_id}
     deps:
       - corpus/treebank/train.spacy
       - corpus/treebank/dev.spacy
     outputs:
-      - training/parser_tagger/model-best
+      - training/parser_tagger_md/model-best
 
   - name: "train-ner-md"
     help: "Train NER component of tl_calamancy_md using floret vectors with pretraining (50k unique vectors)"
@@ -298,6 +320,45 @@ commands:
     outputs:
       - training/ner_md/model-best
 
+  - name: "assemble-md"
+    help: "Assemble the tl_calamancy_md model and package it as a spaCy pipeline"
+    script:
+      - >-
+        python -m spacy assemble configs/assemble.cfg models/tl_calamancy_md
+        --paths.parser_model training/parser_tagger_md/model-best
+        --paths.ner_model training/ner_md/model-best
+      - >-
+        python -m spacy package models/tl_calamancy_md packages/
+        --meta ./meta.json
+        --name calamancy_md
+        --version ${vars.version}
+        --build sdist,wheel
+        --force
+    deps:
+      - training/parser_tagger_md/model-best
+      - training/ner_md/model-best
+    outputs:
+      - packages/tl_calamancy_md-${vars.version}/dist/tl_calamancy_md-${vars.version}.tar.gz
+      - packages/tl_calamancy_md-${vars.version}/dist/tl_calamancy_md-${vars.version}-py3-none-any.whl
+
+  - name: "train-parser-tagger-lg"
+    help: "Train the parser and tagger components using the Universal Dependencies Ugnayan Treebank"
+    script:
+      - >-
+        python -m spacy train
+        configs/parser_tagger.cfg
+        --output training/parser_tagger_lg/
+        --nlp.lang ${vars.lang}
+        --paths.train corpus/treebank/train.spacy
+        --paths.dev corpus/treebank/dev.spacy
+        --paths.vectors vectors/fasttext-tl
+        --gpu-id ${vars.gpu_id}
+    deps:
+      - corpus/treebank/train.spacy
+      - corpus/treebank/dev.spacy
+    outputs:
+      - training/parser_tagger_lg/model-best
+
   - name: "train-ner-lg"
     help: "Train NER component of tl_calamancy_lg using fastText vectors with pretraining (714k unique keys)"
     script:
@@ -314,11 +375,49 @@ commands:
     deps:
       - corpus/ner/train.spacy
       - corpus/ner/dev.spacy
-      - assets/tl_tlunified_pt_chars.bin
       - pretraining/init-tok2vec-lg/model-last.bin
       - vectors/fasttext-tl
     outputs:
       - training/ner_lg/model-best
+
+  - name: "assemble-lg"
+    help: "Assemble the tl_calamancy_lg model and package it as a spaCy pipeline"
+    script:
+      - >-
+        python -m spacy assemble configs/assemble.cfg models/tl_calamancy_lg
+        --paths.parser_model training/parser_tagger_lg/model-best
+        --paths.ner_model training/ner_lg/model-best
+      - >-
+        python -m spacy package models/tl_calamancy_lg packages/
+        --meta ./meta.json
+        --name calamancy_lg
+        --version ${vars.version}
+        --build sdist,wheel
+        --force
+    deps:
+      - training/parser_tagger_lg/model-best
+      - training/ner_lg/model-best
+    outputs:
+      - packages/tl_calamancy_lg-${vars.version}/dist/tl_calamancy_lg-${vars.version}.tar.gz
+      - packages/tl_calamancy_lg-${vars.version}/dist/tl_calamancy_lg-${vars.version}-py3-none-any.whl
+
+  - name: "train-parser-tagger-trf"
+    help: "Train the parser and tagger components using the Universal Dependencies Ugnayan Treebank"
+    script:
+      - >-
+        python -m spacy train
+        configs/parser_tagger_trf.cfg
+        --nlp.lang ${vars.lang}
+        --output training/parser_tagger_trf/
+        --components.transformer.model.name jcblaise/roberta-tagalog-base
+        --paths.train corpus/treebank/train.spacy
+        --paths.dev corpus/treebank/dev.spacy
+        --gpu-id ${vars.gpu_id}
+    deps:
+      - corpus/treebank/train.spacy
+      - corpus/treebank/dev.spacy
+    outputs:
+      - training/parser_tagger_trf/model-best
 
   - name: "train-ner-trf"
     help: "Train NER component of tl_calamancy_trf using context-sensitive vectors from roberta-tagalog"
@@ -341,14 +440,20 @@ commands:
   - name: "assemble-trf"
     help: "Assemble the tl_calamancy_trf model and package it as a spaCy pipeline"
     script:
-      - ls
-
-  - name: "assemble-lg"
-    help: "Assemble the tl_calamancy_lg model and package it as a spaCy pipeline"
-    script:
-      - ls
-
-  - name: "assemble-md"
-    help: "Assemble the tl_calamancy_md model and package it as a spaCy pipeline"
-    script:
-      - ls
+      - >-
+        python -m spacy assemble configs/assemble_trf.cfg models/tl_calamancy_trf
+        --paths.parser_model training/parser_tagger_trf/model-best
+        --paths.ner_model training/ner_trf/model-best
+      - >-
+        python -m spacy package models/tl_calamancy_trf packages/
+        --meta ./meta.json
+        --name calamancy_trf
+        --version ${vars.version}
+        --build sdist,wheel
+        --force
+    deps:
+      - training/parser_tagger_trf/model-best
+      - training/ner_trf/model-best
+    outputs:
+      - packages/tl_calamancy_trf-${vars.version}/dist/tl_calamancy_trf-${vars.version}.tar.gz
+      - packages/tl_calamancy_trf-${vars.version}/dist/tl_calamancy_trf-${vars.version}-py3-none-any.whl

--- a/models/v0.1.0/requirements.txt
+++ b/models/v0.1.0/requirements.txt
@@ -1,0 +1,3 @@
+spacy>=3.5.0
+typer
+wasabi

--- a/models/v0.1.0/requirements.txt
+++ b/models/v0.1.0/requirements.txt
@@ -1,3 +1,5 @@
 spacy>=3.5.0
+spacy-transformers
+pathy[gcs]
 typer
 wasabi

--- a/models/v0.1.0/scripts/merge_treebanks.py
+++ b/models/v0.1.0/scripts/merge_treebanks.py
@@ -1,0 +1,40 @@
+import random
+from pathlib import Path
+from typing import List, Optional
+
+import spacy
+import typer
+from spacy.tokens import DocBin
+from wasabi import msg
+
+
+def merge_treebanks(
+    # fmt: off
+    infiles: List[Path] = typer.Argument(..., help="Path to the spaCy file of treebanks for merging."),
+    outfile: Path = typer.Argument(..., help="Output file to save the merged treebank."),
+    seed: Optional[int] = typer.Option(None, "--seed", help="Random seed for shuffling. Will not shuffle if nothing is passed."),
+    lang: str = typer.Option("tl", "--lang", help="Language code to use for initializing the pipeline."),
+    # fmt: on
+):
+    nlp = spacy.blank(lang)
+    msg.info(f"Merging {len(infiles)} files")
+
+    merged_docs = []
+    for infile in infiles:
+        docs = list(DocBin().from_disk(infile).get_docs(nlp.vocab))
+        msg.text(f"Treebank {infile} has {len(docs)} documents.")
+        merged_docs += docs
+    msg.info(f"Merged file has {len(merged_docs)} documents.")
+
+    if seed:
+        msg.text(f"Shuffling the documents using random seed `{seed}`")
+        random.seed(seed)
+        random.shuffle(merged_docs)
+
+    merged_doc_bin = DocBin(docs=merged_docs)
+    merged_doc_bin.to_disk(outfile)
+    msg.good(f"Saved to {str(outfile)}")
+
+
+if __name__ == "__main__":
+    typer.run(merge_treebanks)

--- a/models/v0.1.0/scripts/split_treebank.py
+++ b/models/v0.1.0/scripts/split_treebank.py
@@ -1,0 +1,44 @@
+import random
+from pathlib import Path
+from typing import List, Optional
+
+import spacy
+import typer
+from spacy.tokens import Doc, DocBin
+from wasabi import msg
+
+
+def split_treebank(
+    # fmt: off
+    infile: Path = typer.Argument(..., help="Path to spaCy file to split."),
+    outdir: Path = typer.Argument(..., help="Directory to store the outputs."),
+    seed: Optional[int] = typer.Option(None, "--seed", help="Random seed for shuffling. Will not shuffle if nothing is passed."),
+    lang: str = typer.Option("tl", "--lang", help="Language code to use for initializing the pipeline."),
+    train_size: float = typer.Option(0.8, "--train-size", help="Size of the training set."),
+    # fmt: on
+):
+    nlp = spacy.blank(lang)
+    docs = list(DocBin().from_disk(infile).get_docs(nlp.vocab))
+
+    if seed:
+        msg.text(f"Shuffling using random seed `{seed}`")
+        random.seed(seed)
+        random.shuffle(docs)
+
+    train_count = int(train_size * len(docs))
+
+    train_docs = docs[:train_count]
+    dev_docs = docs[train_count:]
+    msg.text(f"Train size: {len(train_docs)}, dev size: {len(dev_docs)}")
+
+    def _save_to_disk(docs: List[Doc], outfile: Path):
+        doc_bin = DocBin(docs=docs)
+        doc_bin.to_disk(outfile)
+        msg.good(f"Saved to {str(outfile)}")
+
+    _save_to_disk(train_docs, outdir / "train.spacy")
+    _save_to_disk(dev_docs, outdir / "dev.spacy")
+
+
+if __name__ == "__main__":
+    typer.run(split_treebank)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 dev = [
     "black>=23.1.0",
     "isort>=5.0.0",
-    "flake8>=6.0.0",
+    "ruff>=0.0.272",
     "mypy>=1.0.0"
 ]
 
@@ -53,12 +53,17 @@ profile = "black"
 [tool.pylint.format]
 max-line-length = 88
 
-[tool.flake8]
-ignore = ["E203", "E266", "E501", "E731", "W503", "E741", "F541"]
-max-line-length = 88
-select = ["B", "C", "E", "F", "W", "T4", "B9"]
-exclude = [
-    ".env*",
-    ".git",
-    "__pycache__"
+[tool.ruff]
+ignore = ["E203", "E266", "E501", "E731", "E741", "F541"]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # Pyflakes
+    "Q",    # flake8-quotes
+    "T201"  # flake8-print
 ]
+
+[tool.mypy]
+ignore_missing_imports = true
+no_implicit_optional = true
+allow_redefinition = true


### PR DESCRIPTION
## Description

Closes #16 

This PR adds the initial models for calamanCy. For the first few versions, I think it's better to just have a `_md` to `_trf` model. There are also some design decisions that I used when training the pipelines. Here are the notable ones:

- I merged the two UD treebanks because each one is too small to train a proper model from.
- For the large model, I used the fastText vectors (714k keys). It was trained on CommonCrawl and should be useful for most applications.
- For the transformer model, I am using `jcblaise/roberta-tagalog-base`. During my experiments, there's marginal difference between the `base` and `large` RoBERTa models, so I opted for the smaller version. This resulted to a slightly "leaner" pipeline (700 MB). 
- Please note that the Ugnayan dataset has a Non-commercial license. The TLUnified dataset is also GNU GPL, so it might be best to mention this when sharing to folks. I'd definitely want to rant about licensing, but that would be a topic for another blog post.


## Models and pipelines

  | Model                       | Pipelines                                   | Description                                                                                                  |
  |-----------------------------|---------------------------------------------|--------------------------------------------------------------------------------------------------------------|
  | tl_calamancy_md (73.7 MB)   | tok2vec, tagger, morphologizer, parser, ner | CPU-optimized Tagalog NLP model. Pretrained using the TLUnified dataset. Using floret vectors (50k keys)     |
  | tl_calamancy_lg (431.9 MB)  | tok2vec, tagger, morphologizer, parser, ner | CPU-optimized large Tagalog NLP model. Pretrained using the TLUnified dataset. Using fastText vectors (714k) |
  | tl_calamancy_trf (775.6 MB) | transformer, tagger, parser, ner            | GPU-optimized transformer Tagalog NLP model. Uses roberta-tagalog-base as context vectors.                   |

## Data sources

  | Source                                                                                 | Authors                                          | License         |
  |----------------------------------------------------------------------------------------|--------------------------------------------------|-----------------|
  | [TLUnified Dataset](https://aclanthology.org/2022.lrec-1.703/)                         | Jan Christian Blaise Cruz and Charibeth Cheng    | GNU GPL 3.0     |
  | [UD_Tagalog-TRG](https://universaldependencies.org/treebanks/tl_trg/index.html)        | Stephanie Samson, Daniel Zeman, and Mary Ann Tan | CC BY-SA 3.0    |
  | [UD_Tagalog-Ugnayan](https://universaldependencies.org/treebanks/tl_ugnayan/index.html) | Angelina Aquino                                  | CC BY-NC_SA 4.0 |