### PR TITLE
Add lightweight inference module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,4 +64,5 @@ jobs:
       - name: "Run tests"
         shell: bash
         run: |
+          python -m pip install https://huggingface.co/ljvmiranda921/tl_calamancy_md/resolve/55ef01a244f3ca77676de6ba5a2beea0ba3e0021/tl_calamancy_md-any-py3-none-any.whl --no-deps
           python -m pytest --pyargs $MODULE_NAME

--- a/calamancy/__init__.py
+++ b/calamancy/__init__.py
@@ -1,10 +1,15 @@
 __version__ = "0.1.0"
 
-from .loaders import get_latest_version, models, load
+from .inference import EntityRecognizer, Parser, Tagger
+from .loaders import get_latest_version, load, models
 
 __all__ = [
     "__version__",
     "get_latest_version",
     "models",
     "load",
+    # Inference
+    "EntityRecognizer",
+    "Tagger",
+    "Parser",
 ]

--- a/calamancy/inference.py
+++ b/calamancy/inference.py
@@ -1,0 +1,69 @@
+"""
+This module provides lightweight utility classes for users who are not familiar
+with the spaCy primitives. For training, we recommend following the typical
+procedure as outlined in the spaCy docs: https://spacy.io/usage/training
+"""
+
+from typing import Iterable, Tuple
+
+from .loaders import load
+
+
+class EntityRecognizer:
+    def __init__(self, model: str):
+        """Initialize the named entity recognizer
+
+        model (str): the model name.
+        """
+        self.nlp = load(model)
+
+    def predict(self, text: str) -> Iterable[Tuple[str, str]]:
+        """Return the predicted entities in IOB format for a single text.
+
+        texts (str): the text to get the entities from.
+        YIELDS (Iterable[Tuple[str, str]]): the token and its entity (IOB format).
+        """
+        doc = self.nlp(text)
+        for token in doc:
+            label = (
+                f"{token.ent_iob_}-{token.ent_type_}" if token.ent_iob_ != "O" else "O"
+            )
+            yield (token.text, label)
+
+
+class Tagger:
+    def __init__(self, model: str):
+        """Initialize the parts-of-speech tagger
+
+        model (str): the model name.
+        """
+        self.nlp = load(model)
+
+    def predict(self, text: str) -> Iterable[Tuple[str, str, str]]:
+        """Return the coarse-grained and fine-grained parts-of-speech (POS) tag.
+
+        texts (str): the text to get the POS tags from.
+        YIELDS (Iterable[Tuple[str, str, str]]): the token and its coarse-grained and fine-grained POS tag.
+        """
+        doc = self.nlp(text)
+        for token in doc:
+            yield (token.text, token.pos_, token.tag_)
+
+
+class Parser:
+    def __init__(self, model: str):
+        """Initialize the dependency parser
+
+        model (str): the model name.
+        """
+        self.nlp = load(model)
+
+    def predict(self, text: str) -> Iterable[Tuple[str, str]]:
+        """Return the syntactic dependency relation for a given token.
+
+        text (str): the text to get the dependency relations from.
+        YIELDS (Iterable[Tuple[str, str]]): the token and its dependency relation.
+        """
+        doc = self.nlp(text)
+        for token in doc:
+            yield (token.text, token.dep_)

--- a/calamancy/tests/test_inference.py
+++ b/calamancy/tests/test_inference.py
@@ -1,0 +1,23 @@
+import pytest
+
+from calamancy import EntityRecognizer, Parser, Tagger
+
+tasks = [EntityRecognizer, Tagger, Parser]
+
+
+@pytest.fixture
+def text():
+    return "Ako si Juan de la Cruz"
+
+
+@pytest.fixture
+def calamancy_md():
+    return "tl_calamancy_md-0.1.0"
+
+
+@pytest.mark.parametrize("task", [EntityRecognizer, Tagger, Parser])
+def test_api_is_working(task, text, calamancy_md):
+    """Functional test to check if API contract is followed"""
+    fn = task(model=calamancy_md)
+    preds = list(fn.predict(text))
+    assert len(preds) == len(text.split(" "))


### PR DESCRIPTION
This PR adds a small inference module for users who are not familiar with spaCy primitives. Ideally, it's better to just work on the [spaCy Doc object](https://spacy.io/api/doc), but it might be confusing for those who don't use spaCy often. This inference module simply queries from the outputs of the trained NLP pipeline.

```python
from calamancy import EntityRecognizer
ner = EntityRecognizer("tl_calamancy_md-0.1.0")
entities = ner.predict("Ako si Juan de la Cruz")
```