### PR TITLE
Sticky/wheel dl issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,5 +64,5 @@ jobs:
       - name: "Run tests"
         shell: bash
         run: |
-          python -m pip install https://huggingface.co/ljvmiranda921/tl_calamancy_md/resolve/55ef01a244f3ca77676de6ba5a2beea0ba3e0021/tl_calamancy_md-any-py3-none-any.whl --no-deps
+          python -m pip install https://huggingface.co/ljvmiranda921/tl_calamancy_md/resolve/main/tl_calamancy_md-0.1.0-py3-none-any.whl --no-deps
           python -m pytest --pyargs $MODULE_NAME

--- a/calamancy/loaders.py
+++ b/calamancy/loaders.py
@@ -18,9 +18,9 @@ def _get_models_url() -> Dict[str, str]:
     tracked and the download functions below work as expected.
     """
     return {
-        "tl_calamancy_md-0.1.0": f"https://huggingface.co/ljvmiranda921/tl_calamancy_md/resolve/{GIT_REF}/tl_calamancy_md-any-py3-none-any.whl",
-        "tl_calamancy_lg-0.1.0": f"https://huggingface.co/ljvmiranda921/tl_calamancy_lg/resolve/{GIT_REF}/tl_calamancy_lg-any-py3-none-any.whl",
-        "tl_calamancy_trf-0.1.0": f"https://huggingface.co/ljvmiranda921/tl_calamancy_trf/resolve/{GIT_REF}/tl_calamancy_trf-any-py3-none-any.whl",
+        "tl_calamancy_md-0.1.0": f"https://huggingface.co/ljvmiranda921/tl_calamancy_md/resolve/{GIT_REF}/tl_calamancy_md-0.1.0-py3-none-any.whl",
+        "tl_calamancy_lg-0.1.0": f"https://huggingface.co/ljvmiranda921/tl_calamancy_lg/resolve/{GIT_REF}/tl_calamancy_lg-0.1.0-py3-none-any.whl",
+        "tl_calamancy_trf-0.1.0": f"https://huggingface.co/ljvmiranda921/tl_calamancy_trf/resolve/{GIT_REF}/tl_calamancy_trf-0.1.0-py3-none-any.whl",
     }
 
 

--- a/models/v0.1.0/meta.json
+++ b/models/v0.1.0/meta.json
@@ -2,10 +2,10 @@
     "name": "tl_calamancy",
     "lang": "tl",
     "version": "0.1.0",
-    "spacy_version": ">=3.5.0",
+    "spacy_version": ">=3.5.0,<4.0.0",
     "parent_package": "spacy",
     "requirements": [
-        "spacy-transformers>=1.2.0"
+        "spacy-transformers>=1.2.5,<1.3.0"
     ],
     "description": "calamanCy: Tagalog NLP pipelines in spaCy",
     "author": "Lester James V. Miranda",

--- a/models/v0.1.0/requirements.txt
+++ b/models/v0.1.0/requirements.txt
@@ -1,5 +1,5 @@
 spacy>=3.5.0
-spacy-transformers>=1.2.5
+spacy-transformers>=1.2.5,<1.3.0
 spacy-huggingface-hub>=0.0.9
 pathy[gcs]
 typer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ requires-python = ">=3.7"
 dependencies = [
     "spacy>=3.5.0",
     "wasabi>=0.9.1",
-    "typer>=0.4.2"
+    "typer>=0.4.2",
+    "spacy-transformers>=1.2.5,<1.3.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Issue #36:
The name of the model wheels do not comply to newer PEP.

Fix:
PRs to the corresponding models on huggingface are published.
Hardcoded URLs to these wheels (on this repo) are edited correspondingly. 

--
Issue #37:
The package `spacy-transformers` is not automatically installed when installing the package, nor after downloading the models.

Fix:
Added `spacy-transformers` to `pyproject.toml` of `calamanCy`.

--
Issue #38:
UserWarnings due to updates in `spacy-transformers` package.

Fix:
This can be fixed if the models are updated to match specifications of newer versions of `transformers`. However, since I do not manage these models, I simply restricted the version of `spacy-transformers` to `>=1.2.5,<1.3.0`.

--
Thanks. Let me know if this is helpful or if there are issues.